### PR TITLE
Sht40

### DIFF
--- a/24_sht40/main.go
+++ b/24_sht40/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"image/color"
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/sht4x"
+	"tinygo.org/x/drivers/ssd1306"
+	"tinygo.org/x/tinyfont"
+	"tinygo.org/x/tinyfont/shnm"
+)
+
+var (
+	white = color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF}
+	black = color.RGBA{R: 0x00, G: 0x00, B: 0x00, A: 0xFF}
+)
+
+func main() {
+	machine.I2C0.Configure(machine.I2CConfig{
+		Frequency: 2.8 * machine.MHz,
+		SDA:       machine.GPIO12,
+		SCL:       machine.GPIO13,
+	})
+
+	display := ssd1306.NewI2C(machine.I2C0)
+	display.Configure(ssd1306.Config{
+		Address: 0x3C,
+		Width:   128,
+		Height:  64,
+	})
+	display.SetRotation(drivers.Rotation180)
+	display.ClearDisplay()
+	time.Sleep(50 * time.Millisecond)
+
+	sensor := sht4x.New(machine.I2C0)
+
+	cnt := 0
+	for {
+		for x := int16(0); x < 128; x += 2 {
+			temp, humidity, _ := sensor.ReadTemperatureHumidity()
+			t := fmt.Sprintf("温度 %.2f ℃", float32(temp)/1000)
+			h := fmt.Sprintf("湿度 %.2f ％", float32(humidity)/1000)
+
+			display.ClearBuffer()
+			tinyfont.WriteLine(&display, &shnm.Shnmk12, 5, 10, t, white)
+			tinyfont.WriteLine(&display, &shnm.Shnmk12, 5, 30, h, white)
+			display.Display()
+			time.Sleep(1 * time.Second)
+		}
+		cnt++
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,5 @@ smoketest:
 	tinygo build -o ./out/21_midi2.uf2              --target waveshare-rp2040-zero --size short ./21_midi2
 	tinygo build -o ./out/22_buzzer.uf2             --target waveshare-rp2040-zero --size short ./22_buzzer
 	tinygo build -o ./out/23_akatonbo.uf2           --target waveshare-rp2040-zero --size short ./23_akatonbo
+	tinygo build -o ./out/24_sht40.uf2              --target waveshare-rp2040-zero --size short ./24_sht40
 	tinygo build -o ./out/80_checker.uf2            --target waveshare-rp2040-zero --size short ./80_checker

--- a/README.md
+++ b/README.md
@@ -877,6 +877,38 @@ $ tinygo flash --target waveshare-rp2040-zero --size short  ./22_buzzer/
   * [./23_akatonbo](./23_akatonbo/)
   * https://github.com/triring/7Keyx3Oct
 
+## I2C 接続の温湿度センサーを使う
+
+※ この例を試すには I2C 接続の SHT4x (SHT40 / SHT41 など) が必要です
+※ GROVE 端子に接続してください
+
+![](./images/24_sht40.jpg)
+
+ここでは GROVE 端子に接続した I2C のセンサーを使用してみます。  
+GROVE 端子は oled と同じピンにつながっているので I2C0 を使う必要があります。  
+
+Frequency は 2.8MHz としていますが、スペック上は 400KHz とかに下げる必要があります。  
+
+温度と湿度については `ReadTemperatureHumidity()` で取得可能です。  
+
+```go
+	// import "tinygo.org/x/drivers/sht4x" が必要
+	machine.I2C0.Configure(machine.I2CConfig{
+		Frequency: 2.8 * machine.MHz,
+		SDA:       machine.GPIO12,
+		SCL:       machine.GPIO13,
+	})
+	sensor := sht4x.New(machine.I2C0)
+	temp, humidity, _ := sensor.ReadTemperatureHumidity()
+	t := fmt.Sprintf("温度 %.2f ℃", float32(temp)/1000)
+	h := fmt.Sprintf("湿度 %.2f ％", float32(humidity)/1000)
+```
+
+* SHT4x 入手元
+  * https://www.switch-science.com/products/9270
+  * https://www.switch-science.com/products/8737
+  * https://akizukidenshi.com/catalog/g/g130207/
+
 # sago35/tinygo-keyboard を使う
 
 自作キーボードに必要な要素、というのは人によって違うと思います。


### PR DESCRIPTION
I2C 接続の SHT4x を使う例を追加。

* SHT4x 入手元
  * https://www.switch-science.com/products/9270
  * https://www.switch-science.com/products/8737
  * https://akizukidenshi.com/catalog/g/g130207/